### PR TITLE
Using plugin-base:0.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ sourceSets {
 }
 
 dependencies {
-  compile group: 'com.github.bdpiparva.plugin.base', name: 'gocd-plugin-base', version: '0.0.1'
+  compile group: 'com.github.bdpiparva.plugin.base', name: 'gocd-plugin-base', version: '0.0.3'
   compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: '19.1.0'
   compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
   compile group: 'com.amazonaws', name: 'aws-java-sdk-secretsmanager', version: '1.11.534'

--- a/src/main/java/com/thoughtworks/gocd/secretmanager/aws/AwsPlugin.java
+++ b/src/main/java/com/thoughtworks/gocd/secretmanager/aws/AwsPlugin.java
@@ -1,7 +1,7 @@
 package com.thoughtworks.gocd.secretmanager.aws;
 
+import com.github.bdpiparva.plugin.base.dispatcher.BaseBuilder;
 import com.github.bdpiparva.plugin.base.dispatcher.RequestDispatcher;
-import com.github.bdpiparva.plugin.base.dispatcher.RequestDispatcherBuilder;
 import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
 import com.thoughtworks.go.plugin.api.GoPlugin;
 import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
@@ -19,8 +19,9 @@ public class AwsPlugin implements GoPlugin {
 
     @Override
     public void initializeGoApplicationAccessor(GoApplicationAccessor goApplicationAccessor) {
-        requestDispatcher = RequestDispatcherBuilder
-                .forSecret(goApplicationAccessor)
+        requestDispatcher = BaseBuilder
+                .forSecrets()
+                .v1()
                 .icon("/plugin-icon.png", "image/png")
                 .configMetadata(SecretConfig.class)
                 .configView("/secrets.template.html")

--- a/src/main/java/com/thoughtworks/gocd/secretmanager/aws/SecretConfigLookupExecutor.java
+++ b/src/main/java/com/thoughtworks/gocd/secretmanager/aws/SecretConfigLookupExecutor.java
@@ -7,7 +7,7 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
-import com.github.bdpiparva.plugin.base.dispatcher.LookupExecutor;
+import com.github.bdpiparva.plugin.base.executors.secrets.LookupExecutor;
 import com.google.gson.Gson;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;


### PR DESCRIPTION
Utilizing `gocd-plugin-base:0.0.3`
An earlier version of the same had a bug in `get-template-view`